### PR TITLE
Make matching domains allowed in the Webview more specific

### DIFF
--- a/ColumnModuleView.js
+++ b/ColumnModuleView.js
@@ -31,7 +31,7 @@ export default class ColumnModuleView extends Component {
             ];
             const hostname = new URL(request.url).hostname;
 
-            if (allowedDomains.find((d) => hostname.endsWith(d))) {
+            if (allowedDomains.find((d) => hostname === d || hostname.endsWith(`.${d}`))) {
               return true;
             } else {
               Linking.openURL(request.url).catch(() => null);


### PR DESCRIPTION
## Description

Follow-up to this comment: https://github.com/column-tax/column-react-native-sample/pull/12#discussion_r1001974061

Ensures that we don't potentially open unexpected domains in the webview.

## Testing

Using Expo, tested that we still see the same external link opening behavior.