### PR TITLE
Handle Undefined Top Frame in Android

### DIFF
--- a/ColumnModuleView.js
+++ b/ColumnModuleView.js
@@ -31,7 +31,7 @@ export default class ColumnModuleView extends Component {
             // Always open iframes within the Webview
             // Otherwise, the iframe may open
             // within the external browser.
-            if (!request.isTopFrame) return true;
+            if (request.isTopFrame === false) return true;
 
             // Only allow certain domains to take over the webview
             // This allows us to open certain links externally, like


### PR DESCRIPTION
On Android, `request.isTopFrame` returns undefined when it is actually the top frame.

|  | Android | iPhone |
| - | ------------- | ------------- |
| iframe Request | Not called  | false |
| Top-level Request | undefined  | true |

The explicit check of `request.isTopFrame === false` handles the case of requests within an iFrame on iPhone. On Android, it doesn't appear like these requests bubble up to `onShouldStartLoadWithRequest`.